### PR TITLE
Update version dependency operator 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,7 +205,7 @@ PATH
   specs:
     decidim-question_captcha (0.23.1)
       acts_as_textcaptcha (~> 4.5.1)
-      decidim-core (~> 0.23.1)
+      decidim-core (~> 0.23.3)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,7 +205,7 @@ PATH
   specs:
     decidim-question_captcha (0.23.1)
       acts_as_textcaptcha (~> 4.5.1)
-      decidim-core (= 0.23.1)
+      decidim-core (~> 0.23.1)
 
 GEM
   remote: https://rubygems.org/

--- a/decidim-question_captcha.gemspec
+++ b/decidim-question_captcha.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,lib}/**/*", "LICENSE-AGPLv3.txt", "Rakefile", "README.md"]
 
   s.add_dependency "acts_as_textcaptcha", "~> 4.5.1"
-  s.add_dependency "decidim-core", Decidim::QuestionCaptcha.version
+  s.add_dependency "decidim-core", "~> #{Decidim::QuestionCaptcha.version}"
 end


### PR DESCRIPTION
Allow decidim-core 0.23.2 and other minor versions to run on decidim-module-question_captcha 