### PR TITLE
allow translation of captcha answer error message

### DIFF
--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -10,7 +10,7 @@ en:
   activerecord:
     errors:
       models:
-        comment:
+        registration:
           attributes:
             textcaptcha_answer:
               incorrect: "és incorrecte, proveu una altra pregunta"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,7 +10,7 @@ en:
   activerecord:
     errors:
       models:
-        comment:
+        registration:
           attributes:
             textcaptcha_answer:
               incorrect: "is incorrect, try another question instead"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -10,7 +10,7 @@ en:
   activerecord:
     errors:
       models:
-        comment:
+        registration:
           attributes:
             textcaptcha_answer:
               incorrect: "es incorrecta, intente con otra pregunta en su lugar"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -10,7 +10,7 @@ fr:
   activerecord:
     errors:
       models:
-        comment:
+        registration:
           attributes:
             textcaptcha_answer:
               incorrect: "est incorrect, essayez plutôt une autre question"

--- a/lib/decidim/question_captcha/has_captcha.rb
+++ b/lib/decidim/question_captcha/has_captcha.rb
@@ -71,6 +71,14 @@ module Decidim
 
           { "q" => random_question[:question], "a" => answers } if random_question && answers.present?
         end
+
+        def add_textcaptcha_error(too_slow: false)
+          if too_slow
+            errors.add(:textcaptcha_answer, :expired, message: I18n.t(".expired", scope: "activerecord.errors.models.registration.attributes.textcaptcha_answer"))
+          else
+            errors.add(:textcaptcha_answer, :incorrect, message: I18n.t(".incorrect", scope: "activerecord.errors.models.registration.attributes.textcaptcha_answer"))
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Override `add_textcaptcha_error` method to make it actually translatable