### PR TITLE
Fix behaviour after validation errors, and for languages other than en, es, ca

### DIFF
--- a/app/views/decidim/devise/registrations/new.html.erb
+++ b/app/views/decidim/devise/registrations/new.html.erb
@@ -82,17 +82,15 @@
             </div>
           </div>
 
-          <% if @form.textcaptcha_question %>
+          <%= textcaptcha_fields(f) do %>
             <div class="card" id="question_captcha">
               <div class="card__content">
                 <legend><%= t(".captcha_legend") %></legend>
                 <em><%= t(".captcha_instructions") %></em>
-                <%= textcaptcha_fields(f) do %>
-                  <div class="field">
-                    <%= f.label :textcaptcha_answer, @form.textcaptcha_question %><br/>
-                    <%= f.text_field :textcaptcha_answer, label: t(".textcaptcha_answer"), :value => '' %>
-                  </div>
-                <% end %>
+                <div class="field">
+                  <%= f.label :textcaptcha_answer, @form.textcaptcha_question %><br/>
+                  <%= f.text_field :textcaptcha_answer, label: t(".textcaptcha_answer"), :value => '' %>
+                </div>
               </div>
             </div>
           <% end %>

--- a/app/views/decidim/devise/registrations/new.html.erb
+++ b/app/views/decidim/devise/registrations/new.html.erb
@@ -82,17 +82,19 @@
             </div>
           </div>
 
-          <%= textcaptcha_fields(f) do %>
-            <div class="card" id="question_captcha">
-              <div class="card__content">
-                <legend><%= t(".captcha_legend") %></legend>
-                <em><%= t(".captcha_instructions") %></em>
-                <div class="field">
-                  <%= f.label :textcaptcha_answer, @form.textcaptcha_question %><br/>
-                  <%= f.text_field :textcaptcha_answer, label: t(".textcaptcha_answer"), :value => '' %>
+          <% if @form.perform_textcaptcha? %>
+            <%= textcaptcha_fields(f) do %>
+              <div class="card" id="question_captcha">
+                <div class="card__content">
+                  <legend><%= t(".captcha_legend") %></legend>
+                  <em><%= t(".captcha_instructions") %></em>
+                  <div class="field">
+                    <%= f.label :textcaptcha_answer, @form.textcaptcha_question %><br/>
+                    <%= f.text_field :textcaptcha_answer, label: t(".textcaptcha_answer"), :value => '' %>
+                  </div>
                 </div>
               </div>
-            </div>
+            <% end %>
           <% end %>
 
           <div class="card">

--- a/lib/decidim/question_captcha/has_captcha.rb
+++ b/lib/decidim/question_captcha/has_captcha.rb
@@ -71,6 +71,10 @@ module Decidim
 
           { "q" => random_question[:question], "a" => answers } if random_question && answers.present?
         end
+
+        def textcaptcha_config
+          Decidim::QuestionCaptcha.config
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #9
See matthutchinson/acts_as_textcaptcha#29

It is important to always add the `textcaptcha_key` and `textcaptcha_answer` inputs, even when the captcha question is not being shown. acts_as_textcaptcha offers a helper `textcaptcha_fields` for this, which was used in this module, but inside an `if` statement. This led to wrong behaviour when validation errors occurred on the registration form: The captcha was not shown anymore if it was answered before, but submitting the corrected form would always result in the validation error "was not submitted quickly enough, try another question instead".

Also, this includes a fix for correctly reading the configuration from the initializer. Without this second commit, our configuration for German language only (with German also as default_locale) would silently be ignored, and there would be an infinite loop of [assign_textcaptcha](https://github.com/OpenSourcePolitics/decidim-module-question_captcha/blob/master/lib/decidim/question_captcha/has_captcha.rb#L63) calling itself over and over.

I'm opening this PR for the 0.24 branch, because we still use 0.24. But the commits probably apply just as well to 0.25.